### PR TITLE
Fixed tests for RegExLexer implementation of \w

### DIFF
--- a/Tests/Lexer/Construction/TestRegEx.cs
+++ b/Tests/Lexer/Construction/TestRegEx.cs
@@ -207,13 +207,14 @@ nextLine");
         [TestCase("åäöÅÄÖ")]
         [TestCase("_")]
         [TestCase("01234567890")]
+        [TestCase("\x16C8\x16C1\x16B7\x16DA\x16D6\x16CF")]//Piglet in Runic
         public void TestMatchWordCharactersInclude(string input)
         {
             CheckMatch(input, "\\w+");
         }
 
         [Test]
-        [TestCase("-!\\\"#€%&/\\(\\)='\\|<>")]
+        [TestCase("-!\\\"#€%&/()='|<>,.*^¨`´?+;:@$")]
         public void TestMatchWordCharactersExclude(string input)
         {
             CheckMatchFail(input, "\\w+");


### PR DESCRIPTION
Made tests a bit prettier by moving commented test case (numerals) to the correct test.
You'll want to rebase these before pushing.
